### PR TITLE
6 add caseid to auditevent

### DIFF
--- a/auditlog-fhir-server/src/main/java/ca/uhn/fhir/jpa/starter/MyConsentService.java
+++ b/auditlog-fhir-server/src/main/java/ca/uhn/fhir/jpa/starter/MyConsentService.java
@@ -72,7 +72,7 @@ public class MyConsentService implements IConsentService {
     } else {
       auditEvent.setType(new Coding("Query", "110112", "Audit event: Query has been made"));
     }
-    
+
     auditEvent.setRecorded(new Date());
 
     //retrieve initially created plandefinition by using empty search parameter map
@@ -155,13 +155,5 @@ public class MyConsentService implements IConsentService {
     myAuditEventDao.create(auditEvent);
   }
 
-  //Array toString with removed [brackets] so the result looks like: value1,value2,value3
-  private String toCommaSeparatedStringList(String[] theInputStringArray) {
-    if (theInputStringArray.length > 0) {
-      String commaSeparatedListWithBrackets = Arrays.toString(theInputStringArray);
-      return commaSeparatedListWithBrackets.substring(1, commaSeparatedListWithBrackets.length() - 1);
-    } else {
-      return "";
-    }
-  }
+  
 }

--- a/auditlog-fhir-server/src/main/java/ca/uhn/fhir/jpa/starter/MyConsentService.java
+++ b/auditlog-fhir-server/src/main/java/ca/uhn/fhir/jpa/starter/MyConsentService.java
@@ -9,11 +9,11 @@ import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
 import ca.uhn.fhir.rest.server.interceptor.consent.ConsentOutcome;
 import ca.uhn.fhir.rest.server.interceptor.consent.IConsentContextServices;
 import ca.uhn.fhir.rest.server.interceptor.consent.IConsentService;
+import org.apache.commons.lang3.NotImplementedException;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.*;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.util.Arrays;
 import java.util.Date;
 
 public class MyConsentService implements IConsentService {
@@ -91,7 +91,18 @@ public class MyConsentService implements IConsentService {
     auditEvent.addExtension(basedOnExtension);
 
     AuditEvent.AuditEventAgentComponent agentComponent = new AuditEvent.AuditEventAgentComponent();
-    agentComponent.setRequestor(true);
+    agentComponent.setRequestor(false);
+
+    //set who
+    try {
+      agentComponent.setWho(new Reference(retrieveSubjectIdOrPatientId(theRequestDetails)));
+      CodeableConcept roleType = new CodeableConcept();
+      roleType.addCoding(new Coding("http://terminology.hl7.org/CodeSystem/v3-RoleClass", "PAT", "patient"));
+      agentComponent.addRole(roleType);
+    } catch (Exception e) {
+      System.out.println(e);
+    }
+
     auditEvent.addAgent(agentComponent);
 
     AuditEvent.AuditEventEntityComponent entityComponent = new AuditEvent.AuditEventEntityComponent();
@@ -155,5 +166,43 @@ public class MyConsentService implements IConsentService {
     myAuditEventDao.create(auditEvent);
   }
 
-  
+  //retrieve the first subject reference id (patient id) of a resource (not exhaustive, only for resources of the tested radiological workflow)
+  private String retrieveSubjectIdOrPatientId(RequestDetails theRequestDetails) {
+    //TODO: figure out how to transer caseId for the operation  http://endpoint/DiagnosticReport/$DiagnosticReportId/$fhirToCDA
+
+    // GET request
+    if (theRequestDetails.getRequestType().equals("GET")) {
+      //GET request that contains a subject parameter
+      if (theRequestDetails.getParameters() != null &&
+        !theRequestDetails.getParameters().isEmpty() &&
+        theRequestDetails.getParameters().get("subject") != null) {
+        return theRequestDetails.getParameters().get("subject")[0];
+        //GET request that contains a patient's id
+      } else if (theRequestDetails.getResourceName().equals("Patient") &&
+        theRequestDetails.getId() != null &&
+        theRequestDetails.getId().getValue() != null &&
+        !theRequestDetails.getId().getValue().isEmpty()) {
+        return theRequestDetails.getId().getValue();
+      }
+    }
+
+    //PUT, POST, DELETE... or even GET request as long as it does not contain a parameter "subject"
+    if (theRequestDetails.getResourceName().equals("Patient")) {
+      return theRequestDetails.getId().getValue();
+    } else if (theRequestDetails.getResourceName().equals("Appointment")) {
+      Appointment appointment = (Appointment) theRequestDetails.getResource();
+      return appointment.getParticipantFirstRep().getActor().getReference();
+    } else if (theRequestDetails.getResourceName().equals("Procedure")) {
+      Procedure procedure = (Procedure) theRequestDetails.getResource();
+      return procedure.getSubject().getReference();
+    } else if (theRequestDetails.getResourceName().equals("Media")) {
+      Media media = (Media) theRequestDetails.getResource();
+      return media.getSubject().getReference();
+    } else if (theRequestDetails.getResourceName().equals("DiagnosticReport")) {
+      DiagnosticReport diagnosticReport = (DiagnosticReport) theRequestDetails.getResource();
+      return diagnosticReport.getSubject().getReference();
+    } else {
+      throw new NotImplementedException("There is no existing implementation yet to retrieve a subject for the resource " + theRequestDetails.getResourceName() + ".");
+    }
+  }
 }


### PR DESCRIPTION
i added some proprietary code to realize the inclusion of caseId into our auditevent. unfortunately very specific to use case (only works for our resources in the way we use them). i was wondering if maybe sharing that information as part of the actual request (e.g. http header or as parameter) would make it a little more generic. we have to think about a solution for the last request anyways, because it currently does not contain any caseId yet. so far so good, for now this should work for all requests other than the last one.

closes issue 6: https://aist.fh-hagenberg.at/git/Development/xesonfhir/-/issues/6